### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Additional Configurations:
 
 ## Usage
 
+For large services there are sometimes conflict issues between app service slots, function app slots, and traffic manager. To avoid these issues until this can be resolved you can run apply with the `-parallelism=1` argument
+
+```
+terraform apply -parallelism=1 "dev.tfplan"
+```
+
 ```hcl
 
 module "microservice" {

--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ locals {
 # }
 
 data "external" "current_ipv4" {
-  count = local.is_dev ? 1 : 0
+  count = local.is_dev && var.ip_address != "" ? 1 : 0
 
   program = ["Powershell.exe", "${path.module}/scripts/Get-CurrentIpV4.ps1"]
 }
@@ -91,7 +91,7 @@ locals {
   # current_ip                 = local.is_dev ? local.http_my_public_ip_response : null
 
   # the current_ip is only retrieved and set for the dev environment to simplify developer workflow
-  key_vault_ip_rules = local.is_dev ? ["${data.external.current_ipv4[0].result.ip_address}/32"] : null
+  key_vault_ip_rules = local.is_dev ? var.ip_address != "" ? ["${var.ip_address}/32"] : ["${data.external.current_ipv4[0].result.ip_address}/32"] : null
 }
 
 #################################

--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,9 @@ locals {
   sql_server_elastic_regions          = local.has_sql_server_elastic ? local.sql_server_regions : []
   admin_login                         = "${var.service_name}-admin"
 
+  include_ip_address = var.key_vault_include_ip_address == null ? local.is_dev : var.key_vault_include_ip_address == true
+  lookup_ip_address  = local.include_ip_address && var.ip_address == ""
+
   # 24 characters is used for max storage name
   max_storage_name_length              = 24
   max_region_length                    = reverse(sort([for region in var.regions : length(region)]))[0] # bug is preventing max() from working used sort and reverse instead
@@ -78,7 +81,7 @@ locals {
 # }
 
 data "external" "current_ipv4" {
-  count = local.is_dev && var.ip_address != "" ? 1 : 0
+  count = local.lookup_ip_address ? 1 : 0
 
   program = ["Powershell.exe", "${path.module}/scripts/Get-CurrentIpV4.ps1"]
 }
@@ -91,7 +94,21 @@ locals {
   # current_ip                 = local.is_dev ? local.http_my_public_ip_response : null
 
   # the current_ip is only retrieved and set for the dev environment to simplify developer workflow
-  key_vault_ip_rules = local.is_dev ? var.ip_address != "" ? ["${var.ip_address}/32"] : ["${data.external.current_ipv4[0].result.ip_address}/32"] : null
+
+  #key_vault_ip_rules = local.is_dev ? var.ip_address != "" ? ["${var.ip_address}/32"] : ["${data.external.current_ipv4[0].result.ip_address}/32"] : null
+  external_ip_address = local.lookup_ip_address ? ["${data.external.current_ipv4[0].result.ip_address}/32"] : null
+  current_ip_address  = local.include_ip_address ? coalesce(local.external_ip_address, ["${var.ip_address}/32"]) : null
+  key_vault_network_acls = var.key_vault_network_acls == null && local.include_ip_address ? {
+    default_action             = "Deny"
+    bypass                     = "AzureServices"
+    ip_rules                   = local.current_ip_address
+    virtual_network_subnet_ids = null
+    } : {
+    default_action             = var.key_vault_network_acls.default_action
+    bypass                     = var.key_vault_network_acls.bypass
+    ip_rules                   = local.include_ip_address ? concat(coalesce(local.current_ip_address, []), coalesce(var.key_vault_network_acls.ip_rules, [])) : var.key_vault_network_acls.ip_rules
+    virtual_network_subnet_ids = var.key_vault_network_acls.virtual_network_subnet_ids
+  }
 }
 
 #################################
@@ -176,10 +193,15 @@ resource "azurerm_key_vault" "service" {
     storage_permissions     = var.key_vault_permissions.storage_permissions
   }
 
-  network_acls {
-    default_action = "Deny"
-    bypass         = "AzureServices"
-    ip_rules       = local.key_vault_ip_rules
+  dynamic "network_acls" {
+    for_each = local.key_vault_network_acls != null ? [local.key_vault_network_acls] : []
+
+    content {
+      default_action             = local.key_vault_network_acls.default_action
+      bypass                     = local.key_vault_network_acls.bypass
+      ip_rules                   = local.key_vault_network_acls.ip_rules
+      virtual_network_subnet_ids = local.key_vault_network_acls.virtual_network_subnet_ids
+    }
   }
 }
 
@@ -214,8 +236,13 @@ resource "azurerm_servicebus_namespace" "service" {
 #### SQL Server
 
 resource "random_password" "sql_admin_password" {
-  length  = 16
-  special = false
+  length           = 32
+  min_special      = 1
+  min_numeric      = 1
+  min_upper        = 2
+  min_lower        = 2
+  special          = true
+  override_special = "!#%_-"
 }
 
 resource "azurerm_key_vault_secret" "sql_admin_login" {
@@ -340,12 +367,12 @@ module "microservice" {
   environment_name                = local.environment_name
   callback_path                   = var.callback_path
   key_vault_permissions           = var.key_vault_permissions
-  key_vault_ip_rules              = local.key_vault_ip_rules
+  key_vault_network_acls          = local.key_vault_network_acls
   azurerm_client_config           = data.azurerm_client_config.current
   application_insights            = azurerm_application_insights.service
   storage_accounts                = azurerm_storage_account.service
-  sql_server_id                   = local.has_sql_server ? azurerm_mssql_server.service[local.primary_region].id : null
-  sql_elastic_pool_id             = local.has_sql_server_elastic ? azurerm_mssql_elasticpool.service[local.primary_region].id : null
+  sql_servers                     = local.has_sql_server ? azurerm_mssql_server.service : null
+  sql_elastic_pools               = local.has_sql_server_elastic ? azurerm_mssql_elasticpool.service : null
   cosmosdb_account_name           = local.has_cosmos ? azurerm_cosmosdb_account.service[0].name : null
   cosmosdb_sql_database_name      = local.has_cosmos ? azurerm_cosmosdb_sql_database.service[0].name : null
   cosmosdb_endpoint               = local.has_cosmos ? azurerm_cosmosdb_account.service[0].endpoint : null
@@ -356,9 +383,36 @@ module "microservice" {
   consumption_appservice_plans    = azurerm_app_service_plan.service_consumption
 
   depends_on = [
+    azurerm_storage_account.service,
+    azurerm_servicebus_namespace.service,
+    azurerm_cosmosdb_sql_database.service,
     azurerm_mssql_elasticpool.service,
     azurerm_app_service_plan.service,
     azurerm_app_service_plan.service_consumption
+  ]
+}
+
+resource "time_sleep" "delay_before_traffic" {
+  depends_on = [
+    module.microservice
+  ]
+
+  create_duration  = "15s"
+  destroy_duration = "15s"
+}
+
+# traffic module was moved to it's own module to reduce/prevent intermittent conflict errors between app services, app functions, slots, and traffic manager
+module "microservice_traffic" {
+  source   = "./modules/traffic"
+  for_each = module.microservice
+
+  name                     = each.value.traffic_data.microservice_environment_name
+  resource_group_name      = azurerm_resource_group.service.name
+  azure_endpoint_resources = each.value.traffic_data.azure_endpoint_resources
+
+  depends_on = [
+    module.microservice,
+    time_sleep.delay_before_traffic
   ]
 }
 

--- a/modules/microservice/outputs.tf
+++ b/modules/microservice/outputs.tf
@@ -4,8 +4,16 @@ output "name" {
 }
 
 output "database_id" {
-  description = "SQL database id that was created"
-  value       = local.has_sql_database ? azurerm_mssql_database.microservice[0].id : null
+  description = "SQL primary database id that was created"
+  value       = local.has_sql_database ? azurerm_mssql_database.microservice_primary[0].id : null
+}
+
+output "traffic_data" {
+  description = "Data that can be used to setup traffic routing"
+  value = {
+    microservice_environment_name = local.microservice_environment_name
+    azure_endpoint_resources      = local.azure_endpoint_resources
+  }
 }
 
 output "application_data" {

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -109,16 +109,24 @@ variable "http" {
   default     = null
 }
 
-variable "sql_server_id" {
-  type        = string
-  description = "Server Id for SQL"
-  default     = ""
+variable "sql_servers" {
+  type = map(object({
+    id       = string
+    name     = string
+    location = string
+  }))
+  description = "SQL Servers to use"
+  default     = null
 }
 
-variable "sql_elastic_pool_id" {
-  type        = string
-  description = "Elastic pool Id for SQL"
-  default     = ""
+variable "sql_elastic_pools" {
+  type = map(object({
+    id       = string
+    name     = string
+    location = string
+  }))
+  description = "SQL Elastic Pools to use"
+  default     = null
 }
 
 variable "cosmos_containers" {
@@ -229,7 +237,13 @@ variable "key_vault_permissions" {
   })
 }
 
-variable "key_vault_ip_rules" {
-  description = "One or more IP Addresses, or CIDR Blocks which should be able to access the Key Vault"
-  type        = list(string)
+variable "key_vault_network_acls" {
+  description = "Defines the network acls for key vault"
+  type = object({
+    default_action             = string
+    bypass                     = string
+    ip_rules                   = optional(list(string))
+    virtual_network_subnet_ids = optional(list(string))
+  })
+  default = null
 }

--- a/modules/traffic/main.tf
+++ b/modules/traffic/main.tf
@@ -1,0 +1,30 @@
+resource "azurerm_traffic_manager_profile" "microservice" {
+  name                   = var.name
+  resource_group_name    = var.resource_group_name
+  traffic_routing_method = "Performance"
+
+  dns_config {
+    relative_name = var.name
+    ttl           = 60
+  }
+
+  monitor_config {
+    protocol                     = "https"
+    port                         = 443
+    path                         = "/"
+    interval_in_seconds          = 30
+    timeout_in_seconds           = 10
+    tolerated_number_of_failures = 3
+  }
+}
+
+
+resource "azurerm_traffic_manager_endpoint" "microservice" {
+  for_each = var.azure_endpoint_resources
+
+  name                = each.value.location
+  resource_group_name = var.resource_group_name
+  profile_name        = azurerm_traffic_manager_profile.microservice.name
+  type                = "azureEndpoints"
+  target_resource_id  = each.value.id
+}

--- a/modules/traffic/variables.tf
+++ b/modules/traffic/variables.tf
@@ -1,0 +1,17 @@
+variable "name" {
+  description = "Name for the traffic manager resources"
+  type        = string
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group"
+}
+
+variable "azure_endpoint_resources" {
+  description = "Endpoint resources to be included in traffic management"
+  type = map(object({
+    id       = string
+    location = string
+  }))
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,9 +8,14 @@ output "current_user" {
   value       = data.azuread_user.current_user
 }
 
-output "current_ip" {
-  description = "IP Address retrieved for simpilfying dev configurations. Will be null for non dev environments."
-  value       = local.is_dev ? data.external.current_ipv4[0].result.ip_address : null
+output "external_ip_address" {
+  description = "External IP Address retrieved for simpilfying dev configurations"
+  value       = local.external_ip_address
+}
+
+output "current_ip_address" {
+  description = "IP Address being used for simpilfying dev configurations"
+  value       = local.current_ip_address
 }
 
 output "locals" {

--- a/scripts/Get-CurrentIpV4.ps1
+++ b/scripts/Get-CurrentIpV4.ps1
@@ -1,6 +1,8 @@
-# $ipv4 = Test-Connection -ComputerName (hostname) -Count 1  | Select IPV4Address
-# $ipv4 = $(ipconfig | where {$_ -match 'IPv4.+\s(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})' } | out-null; $Matches[1])
-$returnedIpv4 = (Invoke-WebRequest -uri "https://ifconfig.me/ip").Content
+# recommended solution by Microsoft that is returning correct IP
+# https://techcommunity.microsoft.com/t5/itops-talk-blog/determining-the-public-ip-address-of-your-cloudshell-session/ba-p/1085251
+$client = New-Object System.Net.WebClient
+[xml]$response = $client.DownloadString("http://checkip.dyndns.org")
+$returnedIpv4 = ($response.html.body -split ':')[1].Trim()
 $pattern = "^([1-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(\.([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])){3}$"
 $validIpv4 = $returnedIpv4 -match $pattern
 $ipv4 = if($validIpv4) {$returnedIpv4} else {null}

--- a/variables.tf
+++ b/variables.tf
@@ -147,6 +147,23 @@ variable "storage_account_replication_type" {
   default     = "RAGRS"
 }
 
+variable "key_vault_include_ip_address" {
+  description = "Defines if the current ip should be included in the default network acls for key vaults"
+  type        = bool
+  default     = null
+}
+
+variable "key_vault_network_acls" {
+  description = "Defines the default network acls for key vaults"
+  type = object({
+    default_action             = string
+    bypass                     = string
+    ip_rules                   = optional(list(string))
+    virtual_network_subnet_ids = optional(list(string))
+  })
+  default = null
+}
+
 variable "key_vault_permissions" {
   description = "Permissions applied to Key Vault for the provisioning account"
   type = object({

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "environment" {
   }
 }
 
+variable "ip_address" {
+  type        = string
+  description = "IP Address that will be used for dev environments to add to firewall rules"
+  default     = ""
+}
+
 variable "environment_differentiator" {
   type        = string
   description = "Value can be used to allow multiple envrionments. Logged in azure AD user mail_nickname will be used as default for dev environment unless specified."


### PR DESCRIPTION
Cleaned up IP lookup logic and added an option to pass in keyvault network acls. 
Changed to passing sql server collection instead of just primary id to support creating secondary databases in multiple regions (This fixes the destroy issue when secondary databases aren't manage by Terraform). 
Added traffic module to reduce/prevent intermittent conflict errors between app services, app functions, slots, and traffic manager. 
Added note in readme about -parallelism=1 flag for preventing conflicts. 
Fixed issue with KeyVault policies causing conflicts if being managed separately through azurerm_key_vault_access_policy. 
Changed to create both SystemAssigned and UserAssigned identitied. 
Added commented notes for an issue with identity_ids showing changes due to ordering.
Fixed intermittent issue with password strength for SQL Server Admin.
Added delay between app services/functions and slots to reduce conflicts during create and destroy. 
Added delay between slots and traffic module to reduce conflicts during create and destroy. 
Moved app service slot creation down with functions to keep together after delay. 