### PR TITLE
Enabling Application Owner Specification

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ data "azuread_group" "owner_groups" {
   object_id = each.value
 }
 
-data "azuread_users" "owners_from_group" {
+data "azuread_users" "owner_groups_users" {
   object_ids = flatten([for item in data.azuread_group.owner_groups: item.members])
   ignore_missing = true
 }
@@ -87,7 +87,7 @@ locals {
 
   azure_easyauth_callback                 = "/.auth/login/aad/callback"
 
-  owner_group_members                     = data.azuread_users.owners_from_group!= null ? tolist(data.azuread_users.owners_from_group.object_ids):[]
+  owner_group_members                     = data.azuread_users.owner_groups_users!= null ? tolist(data.azuread_users.owner_groups_users.object_ids):[]
   application_owners                      = distinct(concat(local.owner_group_members, data.azuread_users.owners.object_ids,[data.azurerm_client_config.current.object_id]))
 
   # 24 characters is used for max storage name

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -205,7 +205,7 @@ resource "azuread_application" "microservice" {
   prevent_duplicate_names    = true
   oauth2_allow_implicit_flow = true
   identifier_uris            = [lower("api://${local.full_microservice_environment_name}")]
-  owners                     = [var.azurerm_client_config.object_id]
+  owners                     = var.application_owners
   group_membership_claims    = "None"
   oauth2_permissions         = []
 

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -46,6 +46,12 @@ variable "azure_environment" {
   default     = "public"
 }
 
+variable "application_owners" {
+  description = "ObjectIds who will be an owner of the created applications."
+  type        = list(string)
+  default     = []
+}
+
 variable "environment" {
   description = "Terrform environment we're acting in"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,12 @@ variable "application_owner_user_principal_names" {
   default     = []
 }
 
+variable "application_owner_group_object_ids" {
+  description = "Provides object ids of the groups with the user accounts that will be owners of the created applications"
+  type        = list(string)
+  default     = []
+}
+
 variable "ip_address" {
   description = "IP Address that will be used for dev environments to add to firewall rules"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,12 @@ variable "appsettings_path" {
   default     = "C:\\dev\\"
 }
 
+variable "application_owner_user_principal_names" {
+  description = "Provides user account UPNs that will be owners of the created applications"
+  type        = list(string)
+  default     = []
+}
+
 variable "ip_address" {
   description = "IP Address that will be used for dev environments to add to firewall rules"
   type        = string


### PR DESCRIPTION
Enabling the specification of application owners either by user or group membership.

The calling identity (either service principal or managed identity) is always the owner so it can manage.