### PR TITLE
Adding Service Name to KeyVault so it's more unique

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -225,7 +225,7 @@ resource "azurerm_cosmosdb_sql_database" "service" {
 }
 
 resource "azurerm_key_vault" "service" {
-  name                        = local.environment_differentiator_short2 != "" ? "${local.service_name}-${local.environment_differentiator_short2}-${var.environment}" : "${local.service_name}-${var.environment}"
+  name                        = coalesce(var.keyvault,local.environment_differentiator_short2 != "" ? "${local.service_name}-${local.environment_differentiator_short2}-${var.environment}" : "${local.service_name}-${var.environment}")
   location                    = local.primary_region
   resource_group_name         = local.resource_group_name
   enabled_for_disk_encryption = true
@@ -459,6 +459,7 @@ module "microservice" {
                                         storage_replication_type    = var.static_site_replication_type
                                         storage_tls_version         = var.static_site_tls_version
                                       }: null
+  keyvault                        = each.value.keyvault
 
   depends_on = [
     azurerm_storage_account.service,

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -126,7 +126,7 @@ locals {
 resource "azurerm_key_vault" "microservice" {
   count = local.has_key_vault ? 1 : 0
 
-  name                        = local.environment_differentiator_short != "" ? "${var.service_name}${var.name}-${local.environment_differentiator_short}-${var.environment}" : "${var.service_name}${var.name}-${var.environment}"
+  name                        = coalesce(var.keyvault,local.environment_differentiator_short != "" ? "${var.service_name}${var.name}-${local.environment_differentiator_short}-${var.environment}" : "${var.service_name}${var.name}-${var.environment}")
   location                    = var.primary_region
   resource_group_name         = var.resource_group_name
   enabled_for_disk_encryption = true

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -50,11 +50,11 @@ locals {
   # 24 characters is used for max key vault and storage account names
   max_name_length                      = 24
 
-  max_environment_differentiator_short = local.max_name_length - (length(var.name) + length(var.environment) + 2)
+  max_environment_differentiator_short = local.max_name_length - (length(var.service_name) + length(var.name) + length(var.environment) + 2)
   environment_differentiator_short     = local.max_environment_differentiator_short > 0 ? length(var.environment_differentiator) <= local.max_environment_differentiator_short ? var.environment_differentiator : substr(var.environment_differentiator, 0, local.max_environment_differentiator_short) : ""
   
-  max_environment_differentiator_short_withservice = local.max_name_length - (length(var.service_name) + length(var.name) + length(var.environment) + 2)
-  environment_differentiator_short_withservice     = local.max_environment_differentiator_short_withservice > 0 ? length(var.environment_differentiator) <= local.max_environment_differentiator_short_withservice ? var.environment_differentiator : substr(var.environment_differentiator, 0, local.max_environment_differentiator_short_withservice) : ""
+  max_environment_differentiator_short_noseparator = local.max_name_length - (length(var.service_name) + length(var.name) + length(var.environment) + 2)
+  environment_differentiator_short_noseparator     = local.max_environment_differentiator_short_noseparator > 0 ? length(var.environment_differentiator) <= local.max_environment_differentiator_short_noseparator ? var.environment_differentiator : substr(var.environment_differentiator, 0, local.max_environment_differentiator_short_noseparator) : ""
   
   key_vault_access_policies = [
     {
@@ -126,7 +126,7 @@ locals {
 resource "azurerm_key_vault" "microservice" {
   count = local.has_key_vault ? 1 : 0
 
-  name                        = local.environment_differentiator_short != "" ? "${var.name}-${local.environment_differentiator_short}-${var.environment}" : "${var.name}-${var.environment}"
+  name                        = local.environment_differentiator_short != "" ? "${var.service_name}${var.name}-${local.environment_differentiator_short}-${var.environment}" : "${var.service_name}${var.name}-${var.environment}"
   location                    = var.primary_region
   resource_group_name         = var.resource_group_name
   enabled_for_disk_encryption = true
@@ -592,7 +592,7 @@ resource "azurerm_function_app_slot" "microservice" {
   resource "azurerm_storage_account" "microservice" {
   count = local.has_static_site ? 1 : 0
 
-  name                      = local.environment_differentiator_short_withservice != "" ? "${var.service_name}${var.name}${local.environment_differentiator_short_withservice}${var.environment}" : "${var.service_name}${var.name}${var.environment}"
+  name                      = local.environment_differentiator_short_noseparator != "" ? "${var.service_name}${var.name}${local.environment_differentiator_short_noseparator}${var.environment}" : "${var.service_name}${var.name}${var.environment}"
   resource_group_name       = var.resource_group_name
   location                  = var.primary_region
   account_kind              = var.static_site.storage_kind

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -113,6 +113,12 @@ variable "function" {
   }
 }
 
+variable "keyvault" {
+  description = "Specify name of the KeyVault if the default name is not desired"
+  type        = string
+  default     = ""
+}
+
 variable "require_auth" {
   description = "Specify if the resource requires users to be authenticated or not"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,12 @@ variable "service_name" {
   type        = string
 }
 
+variable "keyvault" {
+  description = "Specify name of the KeyVault if the default name is not desired"
+  type        = string
+  default     = ""
+}
+
 variable "callback_path" {
   description = "Callback path for authorization"
   type        = string
@@ -91,6 +97,7 @@ variable "microservices" {
     name          = string
     appservice    = optional(string)
     function      = optional(string)
+    keyvault      = optional(string)
     require_auth  = optional(bool)
     sql           = optional(string)
     roles         = optional(list(string))


### PR DESCRIPTION
In Azure, the KeyVault name must be globally unique and the current implementation only uses the microservice name / environment combination when creating.  This could easily lead to naming collisions and cause the apply process to fail.

The module has been updated to include the service name in the key vault name so it's more unique.  Also added the ability to override keyvault names if naming collisions become problematic.