### PR TITLE
Enabling Permissions Definition at a Microservice Level

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -438,6 +438,7 @@ module "microservice" {
   function                        = each.value.function
   require_auth                    = each.value.require_auth == null ? false : each.value.require_auth
   application_owners              = local.application_owners
+  application_permissions         = each.value.application_permissions
   sql                             = each.value.sql
   roles                           = each.value.roles
   http                            = each.value.http

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -52,6 +52,18 @@ variable "application_owners" {
   default     = []
 }
 
+variable "application_permissions"{
+  description = "Additional permissions to be added to the application"
+  type = list(object({
+      resource_app_id = string
+      resource_access = list(object({
+        id   = string
+        type = string
+      })
+    )}))
+  default = []
+}
+
 variable "environment" {
   description = "Terrform environment we're acting in"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -106,6 +106,13 @@ variable "microservices" {
     require_auth  = optional(bool)
     sql           = optional(string)
     roles         = optional(list(string))
+    application_permissions = optional(list(object({
+      resource_app_id = string
+      resource_access = list(object({
+        id   = string
+        type = string
+      })
+    )})))
     http = optional(object({
       target    = string
       consumers = list(string)


### PR DESCRIPTION
Adding ability to optionally define permissions for the application at a microservice level.  This will allow applications to have the desired permissions needed and ensure all definitions are in Terraform

Example: Two services, one with _Directory.ReadAll_ and the other with the default permission set
```
microservices = [

      {
        name                = "api1"
        function            = "consumption"
        require_auth        = false,
        application_permissions = [
          {
            resource_app_id = "00000003-0000-0000-c000-000000000000"
            resource_access = [
              {
                id   = "7ab1d382-f21e-4acd-a863-ba3e13f7da61"
                type = "Role"
              }
            ]
          }
        ]
      },
      {
        name                = "api2"
        function            = "consumption"
        require_auth        = true
      },
```