### PR TITLE
Adding scopes for consumed services

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,16 +45,16 @@ data "azuread_domains" "default" {
 
 data "azuread_users" "owners" {
   user_principal_names = var.application_owner_user_principal_names
-  ignore_missing = true
+  ignore_missing       = true
 }
 
 data "azuread_group" "owner_groups" {
-  for_each = zipmap(var.application_owner_group_object_ids,var.application_owner_group_object_ids)
+  for_each  = zipmap(var.application_owner_group_object_ids, var.application_owner_group_object_ids)
   object_id = each.value
 }
 
 data "azuread_users" "owner_groups_users" {
-  object_ids = flatten([for item in data.azuread_group.owner_groups: item.members])
+  object_ids     = flatten([for item in data.azuread_group.owner_groups : item.members])
   ignore_missing = true
 }
 
@@ -85,10 +85,10 @@ locals {
   include_ip_address = var.key_vault_include_ip_address == null ? local.is_dev : var.key_vault_include_ip_address == true
   lookup_ip_address  = local.include_ip_address && var.ip_address == ""
 
-  azure_easyauth_callback                 = "/.auth/login/aad/callback"
+  azure_easyauth_callback = "/.auth/login/aad/callback"
 
-  owner_group_members                     = data.azuread_users.owner_groups_users!= null ? tolist(data.azuread_users.owner_groups_users.object_ids):[]
-  application_owners                      = distinct(concat(local.owner_group_members, data.azuread_users.owners.object_ids,[data.azurerm_client_config.current.object_id]))
+  owner_group_members = data.azuread_users.owner_groups_users != null ? tolist(data.azuread_users.owner_groups_users.object_ids) : []
+  application_owners  = distinct(concat(local.owner_group_members, data.azuread_users.owners.object_ids, [data.azurerm_client_config.current.object_id]))
 
   # 24 characters is used for max storage name
   max_storage_name_length              = 24
@@ -442,6 +442,7 @@ module "microservice" {
   sql                             = each.value.sql
   roles                           = each.value.roles
   http                            = each.value.http
+  scopes                          = each.value.scopes
   cosmos_containers               = each.value.cosmos_containers == null ? [] : each.value.cosmos_containers
   queues                          = each.value.queues == null ? [] : each.value.queues
   resource_group_name             = local.resource_group_name
@@ -470,15 +471,15 @@ module "microservice" {
   appservice_plans                = azurerm_app_service_plan.service
   appservice_deployment_slots     = var.appservice_deployment_slots
   consumption_appservice_plans    = azurerm_app_service_plan.service_consumption
-  static_site                     = each.value.static_site != null ? {
-                                        index_document              = each.value.static_site.index_document
-                                        error_document              = each.value.static_site.error_document
-                                        domain                      = each.value.static_site.domain
-                                        storage_kind                = var.static_site_kind
-                                        storage_tier                = var.static_site_tier
-                                        storage_replication_type    = var.static_site_replication_type
-                                        storage_tls_version         = var.static_site_tls_version
-                                      }: null
+  static_site = each.value.static_site != null ? {
+    index_document           = each.value.static_site.index_document
+    error_document           = each.value.static_site.error_document
+    domain                   = each.value.static_site.domain
+    storage_kind             = var.static_site_kind
+    storage_tier             = var.static_site_tier
+    storage_replication_type = var.static_site_replication_type
+    storage_tls_version      = var.static_site_tls_version
+  } : null
 
   depends_on = [
     azurerm_storage_account.service,

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -271,7 +271,7 @@ resource "azuread_application_app_role" "microservice" {
 }
 
 resource "azuread_application_oauth2_permission" "microservice" {
-  count = local.has_consumers? 1 : 0
+  count = local.has_consumers && var.require_auth ? 1 : 0
   
   application_object_id      = azuread_application.microservice.id
   admin_consent_description  = "Allow the application to access ${azuread_application.microservice.display_name} on behalf of the signed-in user."

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -275,10 +275,10 @@ resource "azuread_application_oauth2_permission" "microservice" {
   for_each = {for item in local.application_scopes:  item.id => item}
 
   application_object_id      = azuread_application.microservice.id
-  admin_consent_description  = each.value.description != null && each.value.description != "" ? each.value.description : "Allow the application to access ${azuread_application.microservice.display_name} with ${each.key.id} permission"
-  admin_consent_display_name = each.value.name != null && each.value.name != "" ? each.value.name : "Access ${azuread_application.microservice.display_name} with ${each.key.id} permission"
-  user_consent_description   = each.value.description != null && each.value.description != "" ? each.value.description : "Allow the application to access ${azuread_application.microservice.display_name} with ${each.key.id} permission"
-  user_consent_display_name  = each.value.name != null && each.value.name != "" ? each.value.name : "Access ${azuread_application.microservice.display_name} with ${each.key.id} permission"
+  admin_consent_description  = each.value.description != null && each.value.description != "" ? each.value.description : "Allow the application to access ${azuread_application.microservice.display_name} with ${each.value.id} permission"
+  admin_consent_display_name = each.value.name != null && each.value.name != "" ? each.value.name : "Access ${azuread_application.microservice.display_name} with ${each.value.id} permission"
+  user_consent_description   = each.value.description != null && each.value.description != "" ? each.value.description : "Allow the application to access ${azuread_application.microservice.display_name} with ${each.value.id} permission"
+  user_consent_display_name  = each.value.name != null && each.value.name != "" ? each.value.name : "Access ${azuread_application.microservice.display_name} with ${each.value.id} permission"
   is_enabled                 = true
   type                       = each.value.type != null && each.value.type != "" ? each.value.type : "Admin"
   value                      = each.value.id

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -31,43 +31,44 @@ locals {
   http_target                        = local.has_http ? var.http.target : local.has_appservice ? "appservice" : local.has_function ? "function" : null
   consumers                          = local.has_http ? var.http.consumers != null ? var.http.consumers : [] : []
   has_consumers                      = length(local.consumers) > 0
-  has_static_site                    = var.static_site !=null
+  application_scopes                 = var.scopes != null ? var.scopes : []
+  has_static_site                    = var.static_site != null
   has_application_permissions        = var.application_permissions != null
   application_permissions            = local.has_application_permissions ? var.application_permissions : []
 
-  graph_resource_app_id              = "00000003-0000-0000-c000-000000000000"
-  graph_application_permissions      = local.has_application_permissions ? [for item in local.application_permissions: item if item.resource_app_id == local.graph_resource_app_id] : []
-  other_application_permissions      = local.has_application_permissions ? [for item in local.application_permissions: item if item.resource_app_id != local.graph_resource_app_id]:[]
-  graph_user_read_access             =  {
-                                        id="e1fe6dd8-ba31-4d61-89e7-88639da4683d" 
-                                        type="Scope"
-                                        }
-  graph_resource_access              = distinct(concat(flatten(local.graph_application_permissions[*].resource_access),[local.graph_user_read_access]))
+  graph_resource_app_id         = "00000003-0000-0000-c000-000000000000"
+  graph_application_permissions = local.has_application_permissions ? [for item in local.application_permissions : item if item.resource_app_id == local.graph_resource_app_id] : []
+  other_application_permissions = local.has_application_permissions ? [for item in local.application_permissions : item if item.resource_app_id != local.graph_resource_app_id] : []
+  graph_user_read_access = {
+    id   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d"
+    type = "Scope"
+  }
+  graph_resource_access = distinct(concat(flatten(local.graph_application_permissions[*].resource_access), [local.graph_user_read_access]))
 
   # For more public / gov differences see:
   #   https://docs.microsoft.com/en-us/azure/azure-government/compare-azure-government-global-azure
-  functions_baseurl                  = var.azure_environment == "usgovernment" ? ".azurewebsites.us" :  ".azurewebsites.net"
-  appservices_baseurl                = var.azure_environment == "usgovernment" ? ".azurewebsites.us" :  ".azurewebsites.net"
-  trafficmanager_baseurl             = var.azure_environment == "usgovernment" ? ".usgovtrafficmanager.net" :  ".trafficmanager.net"
-  
-  trafficmanager_name                = local.full_microservice_environment_name
-  microservice_trafficmanager_url    = lower("https://${local.trafficmanager_name}${local.trafficmanager_baseurl}")
-  
-  appservice_callback_urls           = [for item in local.appservice_plans : lower("https://${var.name}-${item.location}-${var.environment_name}${local.appservices_baseurl}${var.callback_path}")]
-  function_callback_urls             = [for item in local.function_appservice_plans : lower("https://${var.name}-function-${item.location}-${var.environment_name}${local.functions_baseurl}${var.callback_path}")]
-  trafficmanager_callback_urls       = [lower("${local.microservice_trafficmanager_url}/"), lower("${local.microservice_trafficmanager_url}${var.callback_path}")]
-  
-  application_callback_urls          = concat(tolist(local.trafficmanager_callback_urls),tolist(local.appservice_callback_urls),tolist(local.function_callback_urls))
+  functions_baseurl      = var.azure_environment == "usgovernment" ? ".azurewebsites.us" : ".azurewebsites.net"
+  appservices_baseurl    = var.azure_environment == "usgovernment" ? ".azurewebsites.us" : ".azurewebsites.net"
+  trafficmanager_baseurl = var.azure_environment == "usgovernment" ? ".usgovtrafficmanager.net" : ".trafficmanager.net"
+
+  trafficmanager_name             = local.full_microservice_environment_name
+  microservice_trafficmanager_url = lower("https://${local.trafficmanager_name}${local.trafficmanager_baseurl}")
+
+  appservice_callback_urls     = [for item in local.appservice_plans : lower("https://${var.name}-${item.location}-${var.environment_name}${local.appservices_baseurl}${var.callback_path}")]
+  function_callback_urls       = [for item in local.function_appservice_plans : lower("https://${var.name}-function-${item.location}-${var.environment_name}${local.functions_baseurl}${var.callback_path}")]
+  trafficmanager_callback_urls = [lower("${local.microservice_trafficmanager_url}/"), lower("${local.microservice_trafficmanager_url}${var.callback_path}")]
+
+  application_callback_urls = concat(tolist(local.trafficmanager_callback_urls), tolist(local.appservice_callback_urls), tolist(local.function_callback_urls))
 
   # 24 characters is used for max key vault and storage account names
-  max_name_length                      = 24
+  max_name_length = 24
 
   max_environment_differentiator_short = local.max_name_length - (length(var.name) + length(var.environment) + 2)
   environment_differentiator_short     = local.max_environment_differentiator_short > 0 ? length(var.environment_differentiator) <= local.max_environment_differentiator_short ? var.environment_differentiator : substr(var.environment_differentiator, 0, local.max_environment_differentiator_short) : ""
-  
+
   max_environment_differentiator_short_withservice = local.max_name_length - (length(var.service_name) + length(var.name) + length(var.environment) + 2)
   environment_differentiator_short_withservice     = local.max_environment_differentiator_short_withservice > 0 ? length(var.environment_differentiator) <= local.max_environment_differentiator_short_withservice ? var.environment_differentiator : substr(var.environment_differentiator, 0, local.max_environment_differentiator_short_withservice) : ""
-  
+
   key_vault_access_policies = [
     {
       tenant_id = var.azurerm_client_config.tenant_id
@@ -225,25 +226,25 @@ resource "azuread_application" "microservice" {
   # Post used to find the correct "magic" Guids
   # https://partlycloudy.blog/2019/12/15/fully-automated-creation-of-an-aad-integrated-kubernetes-cluster-with-terraform/
   required_resource_access {
-      resource_app_id = local.graph_resource_app_id
+    resource_app_id = local.graph_resource_app_id
 
-      dynamic "resource_access" {
-        for_each = toset(local.graph_resource_access)
-        content{
-          id   = resource_access.key.id
-          type = resource_access.key.type
-        }
+    dynamic "resource_access" {
+      for_each = toset(local.graph_resource_access)
+      content {
+        id   = resource_access.key.id
+        type = resource_access.key.type
       }
     }
-  
-  dynamic "required_resource_access"{
+  }
+
+  dynamic "required_resource_access" {
     for_each = toset(local.other_application_permissions)
     content {
       resource_app_id = required_resource_access.key.resource_app_id
 
       dynamic "resource_access" {
         for_each = toset(required_resource_access.key.resource_access)
-        content{
+        content {
           id   = resource_access.key.id
           type = resource_access.key.type
         }
@@ -271,16 +272,16 @@ resource "azuread_application_app_role" "microservice" {
 }
 
 resource "azuread_application_oauth2_permission" "microservice" {
-  count = local.has_consumers && var.require_auth ? 1 : 0
-  
+  for_each = {for item in local.application_scopes:  item.id => item}
+
   application_object_id      = azuread_application.microservice.id
-  admin_consent_description  = "Allow the application to access ${azuread_application.microservice.display_name} on behalf of the signed-in user."
-  admin_consent_display_name = "Access ${azuread_application.microservice.display_name}"
+  admin_consent_description  = each.value.description != null && each.value.description != "" ? each.value.description : "Allow the application to access ${azuread_application.microservice.display_name} with ${each.key.id} permission"
+  admin_consent_display_name = each.value.name != null && each.value.name != "" ? each.value.name : "Access ${azuread_application.microservice.display_name} with ${each.key.id} permission"
+  user_consent_description   = each.value.description != null && each.value.description != "" ? each.value.description : "Allow the application to access ${azuread_application.microservice.display_name} with ${each.key.id} permission"
+  user_consent_display_name  = each.value.name != null && each.value.name != "" ? each.value.name : "Access ${azuread_application.microservice.display_name} with ${each.key.id} permission"
   is_enabled                 = true
-  type                       = "User"
-  user_consent_description   = "Allow the application to access ${azuread_application.microservice.display_name} on your behalf"
-  user_consent_display_name  = "Access ${azuread_application.microservice.display_name}"
-  value                      = "user_impersonation"
+  type                       = each.value.type != null && each.value.type != "" ? each.value.type : "Admin"
+  value                      = each.value.id
 }
 
 ### SQL Database
@@ -494,15 +495,15 @@ resource "azurerm_app_service" "microservice" {
 
     content {
       enabled = true
-      active_directory  {
-          client_id = azuread_application.microservice.application_id
-          allowed_audiences = [ 
-            "https://${var.name}-${each.value.location}-${var.environment_name}${local.appservices_baseurl}",
-              local.microservice_trafficmanager_url 
-            ]
+      active_directory {
+        client_id = azuread_application.microservice.application_id
+        allowed_audiences = [
+          "https://${var.name}-${each.value.location}-${var.environment_name}${local.appservices_baseurl}",
+          local.microservice_trafficmanager_url
+        ]
       }
       default_provider = "AzureActiveDirectory"
-      issuer = "https://sts.windows.net/${var.azurerm_client_config.tenant_id}"
+      issuer           = "https://sts.windows.net/${var.azurerm_client_config.tenant_id}"
     }
   }
 }
@@ -538,21 +539,21 @@ resource "azurerm_function_app" "microservice" {
     type         = local.appservice_identity_type
     identity_ids = local.user_assigned_identity_ids
   }
-  
+
   dynamic "auth_settings" {
     for_each = var.require_auth ? [var.require_auth] : []
 
     content {
       enabled = true
-      active_directory  {
-         client_id = azuread_application.microservice.application_id
-         allowed_audiences = [ 
-           "https://${var.name}-function-${each.value.location}-${var.environment_name}${local.functions_baseurl}",
-           local.microservice_trafficmanager_url  
-           ]
+      active_directory {
+        client_id = azuread_application.microservice.application_id
+        allowed_audiences = [
+          "https://${var.name}-function-${each.value.location}-${var.environment_name}${local.functions_baseurl}",
+          local.microservice_trafficmanager_url
+        ]
       }
       default_provider = "AzureActiveDirectory"
-      issuer = "https://sts.windows.net/${var.azurerm_client_config.tenant_id}"
+      issuer           = "https://sts.windows.net/${var.azurerm_client_config.tenant_id}"
     }
   }
 
@@ -633,7 +634,7 @@ resource "azurerm_function_app_slot" "microservice" {
 }
 
 ### Static Site
-  resource "azurerm_storage_account" "microservice" {
+resource "azurerm_storage_account" "microservice" {
   count = local.has_static_site ? 1 : 0
 
   name                      = local.environment_differentiator_short_withservice != "" ? "${var.service_name}${var.name}${local.environment_differentiator_short_withservice}${var.environment}" : "${var.service_name}${var.name}${var.environment}"
@@ -645,11 +646,11 @@ resource "azurerm_function_app_slot" "microservice" {
   enable_https_traffic_only = true
   min_tls_version           = var.static_site.storage_tls_version
   custom_domain {
-    name                    = var.static_site.domain != null ? var.static_site.domain : ""
+    name = var.static_site.domain != null ? var.static_site.domain : ""
   }
   static_website {
-    index_document          = var.static_site.index_document
-    error_404_document      = coalesce(var.static_site.error_document,var.static_site.index_document)
+    index_document     = var.static_site.index_document
+    error_404_document = coalesce(var.static_site.error_document, var.static_site.index_document)
   }
 }
 ### Traffic Manager

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -52,15 +52,15 @@ variable "application_owners" {
   default     = []
 }
 
-variable "application_permissions"{
+variable "application_permissions" {
   description = "Additional permissions to be added to the application"
   type = list(object({
-      resource_app_id = string
-      resource_access = list(object({
-        id   = string
-        type = string
+    resource_app_id = string
+    resource_access = list(object({
+      id   = string
+      type = string
       })
-    )}))
+  ) }))
   default = []
 }
 
@@ -146,6 +146,17 @@ variable "sql" {
     condition     = var.sql == null ? true : contains(["", "server", "elastic"], lower(var.sql))
     error_message = "Value must be '', 'server', or 'elastic'."
   }
+}
+
+variable "scopes" {
+  description = "Scopes to define on the application"
+  type = list(object({
+    id          = string
+    type        = optional(string)
+    name        = optional(string)
+    description = optional(string)
+  }))
+  default = []
 }
 
 variable "http" {
@@ -333,16 +344,16 @@ variable "key_vault_network_acls" {
   default = null
 }
 
-variable "static_site" { 
+variable "static_site" {
   description = "Defines the static site settings"
   type = object({
-      index_document                = string
-      error_document                = string
-      domain                        = string
-      storage_kind                  = string
-      storage_tier                  = string
-      storage_replication_type      = string
-      storage_tls_version           = string
-    })
+    index_document           = string
+    error_document           = string
+    domain                   = string
+    storage_kind             = string
+    storage_tier             = string
+    storage_replication_type = string
+    storage_tls_version      = string
+  })
   default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -113,6 +113,12 @@ variable "microservices" {
         type = string
       })
     )})))
+    scopes = optional(list(object({
+      id            = string
+      type          = string
+      name          = string
+      description   = string
+    })))
     http = optional(object({
       target    = string
       consumers = list(string)


### PR DESCRIPTION
When a service is consumed by another service, we need the ability to define 0 to many scopes

Updating the microservice code so that scopes can be defined at the microservice level. Example:

```
{
    name         = "idex-api"
    function     = "consumption"
    roles        = ["Admin", "Support"]
    require_auth = true
    scopes = [
      {
        id          = "Api.Access"
        type        = ""
        name        = "" 
        description = ""
      }
    ]
```

```
{
    name         = "idex-api"
    function     = "consumption"
    roles        = ["Admin", "Support"]
    require_auth = true
    #custom_domain       = var.api_domain
    #ssl_certificate_source = "appservicemanaged"
    scopes = [
        {
          id            = "Api.Access"
          type          = "Admin" 
          name          = "Access the API" 
          description   = "Allow the application to access the API on your behalf." 
        }
      ]
```