### PR TITLE
Adding ability to specify custom domains

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -469,10 +469,10 @@ module "microservice" {
   appservice_plans                = azurerm_app_service_plan.service
   appservice_deployment_slots     = var.appservice_deployment_slots
   consumption_appservice_plans    = azurerm_app_service_plan.service_consumption
+  custom_domain                   = each.value.custom_domain
   static_site                     = each.value.static_site != null ? {
                                         index_document              = each.value.static_site.index_document
                                         error_document              = each.value.static_site.error_document
-                                        domain                      = each.value.static_site.domain
                                         storage_kind                = var.static_site_kind
                                         storage_tier                = var.static_site_tier
                                         storage_replication_type    = var.static_site_replication_type

--- a/main.tf
+++ b/main.tf
@@ -470,6 +470,7 @@ module "microservice" {
   appservice_deployment_slots     = var.appservice_deployment_slots
   consumption_appservice_plans    = azurerm_app_service_plan.service_consumption
   custom_domain                   = each.value.custom_domain
+  ssl_certificate_source          = each.value.ssl_certificate_source
   static_site                     = each.value.static_site != null ? {
                                         index_document              = each.value.static_site.index_document
                                         error_document              = each.value.static_site.error_document

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -32,6 +32,7 @@ locals {
   consumers                          = local.has_http ? var.http.consumers != null ? var.http.consumers : [] : []
   has_static_site                    = var.static_site !=null
   has_custom_domain                  = var.custom_domain != null && var.custom_domain != ""
+  ssl_certificate_source             = var.ssl_certificate_source != null ? lower(var.ssl_certificate_source) : ""
 
   # For more public / gov differences see:
   #   https://docs.microsoft.com/en-us/azure/azure-government/compare-azure-government-global-azure
@@ -604,6 +605,12 @@ resource "azurerm_app_service_custom_hostname_binding" "microservice" {
   hostname            = var.custom_domain
   app_service_name    = each.key
   resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_app_service_managed_certificate" "microservice" {
+  for_each = local.ssl_certificate_source == "appservicemanaged" ? azurerm_app_service_custom_hostname_binding.microservice : {}
+
+  custom_hostname_binding_id = each.value.id
 }
 
 ### Static Site

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -590,6 +590,22 @@ resource "azurerm_function_app_slot" "microservice" {
   ]
 }
 
+### Custom Domain for App Services
+locals {
+  app_service_names  = [for item in azurerm_app_service.microservice : item.name]
+  function_appservice_names  = [for item in azurerm_function_app.microservice : item.name]
+  all_app_service_names = concat(tolist(local.app_service_names),tolist(local.function_appservice_names))
+  custom_domain_app_service_names = local.has_custom_domain ? local.all_app_service_names : []
+}
+
+resource "azurerm_app_service_custom_hostname_binding" "microservice" {
+  for_each = toset(local.custom_domain_app_service_names)
+  
+  hostname            = var.custom_domain
+  app_service_name    = each.key
+  resource_group_name = var.resource_group_name
+}
+
 ### Static Site
   resource "azurerm_storage_account" "microservice" {
   count = local.has_static_site ? 1 : 0

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -603,7 +603,7 @@ resource "azurerm_function_app_slot" "microservice" {
   enable_https_traffic_only = true
   min_tls_version           = var.static_site.storage_tls_version
   custom_domain {
-    name                    = var.has_custom_domain ? var.custom_domain : ""
+    name                    = local.has_custom_domain ? var.custom_domain : ""
   }
   static_website {
     index_document          = var.static_site.index_document

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -338,3 +338,8 @@ variable "custom_domain" {
   description = "Custom domain where the service is exposed at"
   type        = string
 }
+
+variable "ssl_certificate_source" {
+  description = "Source to retrieve an ssl certificate for the service"
+  type        = string
+}

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -326,11 +326,15 @@ variable "static_site" {
   type = object({
       index_document                = string
       error_document                = string
-      domain                        = string
       storage_kind                  = string
       storage_tier                  = string
       storage_replication_type      = string
       storage_tls_version           = string
     })
   default = null
+}
+
+variable "custom_domain" {
+  description = "Custom domain where the service is exposed at"
+  type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -106,6 +106,7 @@ variable "microservices" {
     require_auth  = optional(bool)
     sql           = optional(string)
     roles         = optional(list(string))
+    custom_domain = optional(string)
     http = optional(object({
       target    = string
       consumers = list(string)
@@ -122,7 +123,6 @@ variable "microservices" {
     static_site = optional(object({
       index_document                = string
       error_document                = string
-      domain                        = string
     }))
   }))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -100,29 +100,30 @@ variable "signed_out_callback_path" {
 variable "microservices" {
   description = "This will describe your microservices to determine which resources are needed"
   type = list(object({
-    name          = string
-    appservice    = optional(string)
-    function      = optional(string)
-    require_auth  = optional(bool)
-    sql           = optional(string)
-    roles         = optional(list(string))
-    custom_domain = optional(string)
-    http = optional(object({
-      target    = string
-      consumers = list(string)
+    name                    = string
+    appservice              = optional(string)
+    function                = optional(string)
+    require_auth            = optional(bool)
+    sql                     = optional(string)
+    roles                   = optional(list(string))
+    custom_domain           = optional(string)
+    ssl_certificate_source  = optional(string)
+    http                    = optional(object({
+      target              = string
+      consumers           = list(string)
     }))
-    queues = optional(list(object({
-      name       = string
-      publishers = list(string)
+    queues                  = optional(list(object({
+      name                = string
+      publishers          = list(string)
     })))
-    cosmos_containers = optional(list(object({
+    cosmos_containers       = optional(list(object({
       name               = string
       partition_key_path = string
       max_throughput     = number
     })))
-    static_site = optional(object({
-      index_document                = string
-      error_document                = string
+    static_site             = optional(object({
+      index_document     = string
+      error_document     = string
     }))
   }))
 }


### PR DESCRIPTION
Adding the ability to specify custom domains for a microservice.  This will enable services to be exposed with custom domains so that:
1. Ensure the static site custom domain value is set correctly
2. Add the correct authentication callback urls with the custom domain so users are authenticated correctly