### PR TITLE
Enable definition of scopes per service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -443,6 +443,7 @@ module "microservice" {
   sql                             = each.value.sql
   roles                           = each.value.roles
   http                            = each.value.http
+  scopes                          = each.value.scopes
   cosmos_containers               = each.value.cosmos_containers == null ? [] : each.value.cosmos_containers
   queues                          = each.value.queues == null ? [] : each.value.queues
   resource_group_name             = local.resource_group_name

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -154,6 +154,17 @@ variable "sql" {
   }
 }
 
+variable "scopes" {
+  description = "Scopes to define on the application"
+  type = list(object({
+    id          = string
+    type        = optional(string)
+    name        = optional(string)
+    description = optional(string)
+  }))
+  default = []
+}
+
 variable "http" {
   description = "Target option for http traffic manager configuration and optional consumers to request role"
   type = object({

--- a/variables.tf
+++ b/variables.tf
@@ -119,6 +119,12 @@ variable "microservices" {
         type = string
         })
     ) })))
+    scopes = optional(list(object({
+      id            = string
+      type          = string
+      name          = string
+      description   = string
+    })))
     http = optional(object({
       target    = string
       consumers = list(string)


### PR DESCRIPTION
When a service is consumed by another service, we need the ability to define 0 to many scopes

Updating the microservice code so that scopes can be defined at the microservice level. Example:

```
{
    name         = "idex-api"
    function     = "consumption"
    roles        = ["Admin", "Support"]
    require_auth = true
    scopes = [
      {
        id          = "Api.Access"
        type        = ""
        name        = "" 
        description = ""
      }
    ]
```

```
{
    name         = "idex-api"
    function     = "consumption"
    roles        = ["Admin", "Support"]
    require_auth = true
    #custom_domain       = var.api_domain
    #ssl_certificate_source = "appservicemanaged"
    scopes = [
        {
          id            = "Api.Access"
          type          = "Admin" 
          name          = "Access the API" 
          description   = "Allow the application to access the API on your behalf." 
        }
      ]
```