### PR TITLE
Enable ability to specify custom domain

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -444,6 +444,8 @@ module "microservice" {
   roles                           = each.value.roles
   http                            = each.value.http
   scopes                          = each.value.scopes
+  custom_domain                   = each.value.custom_domain
+  ssl_certificate_source          = each.value.ssl_certificate_source
   cosmos_containers               = each.value.cosmos_containers == null ? [] : each.value.cosmos_containers
   queues                          = each.value.queues == null ? [] : each.value.queues
   resource_group_name             = local.resource_group_name

--- a/main.tf
+++ b/main.tf
@@ -508,9 +508,11 @@ module "microservice_traffic" {
   source   = "./modules/traffic"
   for_each = var.exclude_hosts ? {} : module.microservice
 
-  name                     = each.value.traffic_data.microservice_environment_name
-  resource_group_name      = local.resource_group_name
-  azure_endpoint_resources = each.value.traffic_data.azure_endpoint_resources
+  name                      = each.value.traffic_data.microservice_environment_name
+  resource_group_name       = local.resource_group_name
+  azure_endpoint_resources  = each.value.traffic_data.azure_endpoint_resources
+  static_endpoint_resources = each.value.traffic_data.static_endpoint_resources
+  custom_domain             = each.value.traffic_data.custom_domain
 
   depends_on = [
     module.microservice,

--- a/main.tf
+++ b/main.tf
@@ -478,7 +478,6 @@ module "microservice" {
   static_site = each.value.static_site != null ? {
     index_document           = each.value.static_site.index_document
     error_document           = each.value.static_site.error_document
-    domain                   = each.value.static_site.domain
     storage_kind             = var.static_site_kind
     storage_tier             = var.static_site_tier
     storage_replication_type = var.static_site_replication_type

--- a/main.tf
+++ b/main.tf
@@ -513,6 +513,7 @@ module "microservice_traffic" {
   azure_endpoint_resources  = each.value.traffic_data.azure_endpoint_resources
   static_endpoint_resources = each.value.traffic_data.static_endpoint_resources
   custom_domain             = each.value.traffic_data.custom_domain
+  tls_certificate           = each.value.traffic_data.tls_certificate
 
   depends_on = [
     module.microservice,

--- a/main.tf
+++ b/main.tf
@@ -445,7 +445,7 @@ module "microservice" {
   http                            = each.value.http
   scopes                          = each.value.scopes
   custom_domain                   = each.value.custom_domain
-  ssl_certificate_source          = each.value.ssl_certificate_source
+  tls_certificate                 = each.value.tls_certificate
   cosmos_containers               = each.value.cosmos_containers == null ? [] : each.value.cosmos_containers
   queues                          = each.value.queues == null ? [] : each.value.queues
   resource_group_name             = local.resource_group_name

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -692,9 +692,6 @@ resource "azurerm_storage_account" "microservice" {
   account_replication_type  = var.static_site.storage_replication_type
   enable_https_traffic_only = true
   min_tls_version           = var.static_site.storage_tls_version
-  custom_domain {
-    name = local.has_custom_domain ? var.custom_domain : ""
-  }
   static_website {
     index_document     = var.static_site.index_document
     error_404_document = coalesce(var.static_site.error_document, var.static_site.index_document)

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -32,6 +32,7 @@ locals {
   consumers                          = local.has_http ? var.http.consumers != null ? var.http.consumers : [] : []
   has_static_site                    = var.static_site != null
   has_custom_domain                  = var.custom_domain != null && var.custom_domain != ""
+  ssl_certificate_source             = var.ssl_certificate_source != null ? lower(var.ssl_certificate_source) : ""
   has_application_permissions        = var.application_permissions != null
   application_permissions            = local.has_application_permissions ? var.application_permissions : []
   application_scopes                 = var.scopes != null ? var.scopes : []

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -31,6 +31,7 @@ locals {
   http_target                        = local.has_http ? var.http.target : local.has_appservice ? "appservice" : local.has_function ? "function" : null
   consumers                          = local.has_http ? var.http.consumers != null ? var.http.consumers : [] : []
   has_static_site                    = var.static_site != null
+  has_custom_domain                  = var.custom_domain != null && var.custom_domain != ""
   has_application_permissions        = var.application_permissions != null
   application_permissions            = local.has_application_permissions ? var.application_permissions : []
   application_scopes                 = var.scopes != null ? var.scopes : []
@@ -668,7 +669,7 @@ resource "azurerm_storage_account" "microservice" {
   enable_https_traffic_only = true
   min_tls_version           = var.static_site.storage_tls_version
   custom_domain {
-    name = var.custom_domain != null ? var.custom_domain : ""
+    name = local.has_custom_domain ? var.custom_domain : ""
   }
   static_website {
     index_document     = var.static_site.index_document

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -34,10 +34,10 @@ locals {
   has_application_permissions        = var.application_permissions != null
   application_permissions            = local.has_application_permissions ? var.application_permissions : []
   application_scopes                 = var.scopes != null ? var.scopes : []
-  
-  graph_resource_app_id              = "00000003-0000-0000-c000-000000000000"
-  graph_application_permissions      = local.has_application_permissions ? [for item in local.application_permissions : item if item.resource_app_id == local.graph_resource_app_id] : []
-  other_application_permissions      = local.has_application_permissions ? [for item in local.application_permissions : item if item.resource_app_id != local.graph_resource_app_id] : []
+
+  graph_resource_app_id         = "00000003-0000-0000-c000-000000000000"
+  graph_application_permissions = local.has_application_permissions ? [for item in local.application_permissions : item if item.resource_app_id == local.graph_resource_app_id] : []
+  other_application_permissions = local.has_application_permissions ? [for item in local.application_permissions : item if item.resource_app_id != local.graph_resource_app_id] : []
   graph_user_read_access = {
     id   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d"
     type = "Scope"
@@ -271,7 +271,7 @@ resource "azuread_application_app_role" "microservice" {
 }
 
 resource "azuread_application_oauth2_permission" "microservice" {
-  for_each = {for item in local.application_scopes:  item.id => item}
+  for_each = { for item in local.application_scopes : item.id => item }
 
   application_object_id      = azuread_application.microservice.id
   admin_consent_description  = each.value.description != null && each.value.description != "" ? each.value.description : "Allow the application to access ${azuread_application.microservice.display_name} with ${each.value.id} permission"
@@ -645,7 +645,7 @@ resource "azurerm_storage_account" "microservice" {
   enable_https_traffic_only = true
   min_tls_version           = var.static_site.storage_tls_version
   custom_domain {
-    name = var.static_site.domain != null ? var.static_site.domain : ""
+    name = var.custom_domain != null ? var.custom_domain : ""
   }
   static_website {
     index_document     = var.static_site.index_document

--- a/modules/microservice/outputs.tf
+++ b/modules/microservice/outputs.tf
@@ -13,6 +13,7 @@ output "traffic_data" {
   value = {
     microservice_environment_name = local.trafficmanager_name
     azure_endpoint_resources      = local.azure_endpoint_resources
+    custom_domain                 = var.custom_domain
   }
 }
 

--- a/modules/microservice/outputs.tf
+++ b/modules/microservice/outputs.tf
@@ -13,6 +13,7 @@ output "traffic_data" {
   value = {
     microservice_environment_name = local.trafficmanager_name
     azure_endpoint_resources      = local.azure_endpoint_resources
+    static_endpoint_resources     = local.static_endpoint_resources
     custom_domain                 = var.custom_domain
   }
 }

--- a/modules/microservice/outputs.tf
+++ b/modules/microservice/outputs.tf
@@ -15,6 +15,7 @@ output "traffic_data" {
     azure_endpoint_resources      = local.azure_endpoint_resources
     static_endpoint_resources     = local.static_endpoint_resources
     custom_domain                 = var.custom_domain
+    tls_certificate               = var.tls_certificate
   }
 }
 

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -174,6 +174,17 @@ variable "http" {
   default = null
 }
 
+variable "custom_domain" {
+  description = "Custom domain name to use for exposing the service"
+  type        = string
+  default     = ""
+}
+
+variable "ssl_certificate_source" {
+  description = "Source to retrieve an ssl certificate for the service"
+  type        = string
+}
+
 variable "azuread_instance" {
   description = "Instance of Azure AD"
   type        = string

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -185,6 +185,7 @@ variable "tls_certificate" {
   type        = object({
       source        = string
       secret_id     = optional(string)
+      keyvault_id   = optional(string)
     })
 }
 

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -180,9 +180,12 @@ variable "custom_domain" {
   default     = ""
 }
 
-variable "ssl_certificate_source" {
-  description = "Source to retrieve an ssl certificate for the service"
-  type        = string
+variable "tls_certificate" {
+  description = "Source to retrieve an tls/ssl certificate for the service"
+  type        = object({
+      source        = string
+      secret_id     = optional(string)
+    })
 }
 
 variable "azuread_instance" {

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -366,7 +366,6 @@ variable "static_site" {
   type = object({
     index_document           = string
     error_document           = string
-    domain                   = string
     storage_kind             = string
     storage_tier             = string
     storage_replication_type = string

--- a/modules/traffic/main.tf
+++ b/modules/traffic/main.tf
@@ -1,4 +1,11 @@
+locals {
+  has_traffic_manager_resources = var.azure_endpoint_resources == null ? false : length(var.azure_endpoint_resources) > 0
+  has_frontdoor_resources       = var.static_endpoint_resources == null ? false : length(var.static_endpoint_resources) > 0
+  frontdoor_hosts               = local.has_frontdoor_resources ? var.static_endpoint_resources : {}
+}
 resource "azurerm_traffic_manager_profile" "microservice" {
+  count = local.has_traffic_manager_resources ? 1 : 0
+
   name                   = var.name
   resource_group_name    = var.resource_group_name
   traffic_routing_method = "Performance"
@@ -24,7 +31,58 @@ resource "azurerm_traffic_manager_endpoint" "microservice" {
 
   name                = each.value.location
   resource_group_name = var.resource_group_name
-  profile_name        = azurerm_traffic_manager_profile.microservice.name
+  profile_name        = azurerm_traffic_manager_profile.microservice[0].name
   type                = "azureEndpoints"
   target_resource_id  = each.value.id
+}
+
+resource "azurerm_frontdoor" "microservice" {
+  count = local.has_frontdoor_resources ? 1 : 0
+
+  name                                         = var.name
+  resource_group_name                          = var.resource_group_name
+  enforce_backend_pools_certificate_name_check = false
+
+  routing_rule {
+    name               = "routing-default"
+    accepted_protocols = ["Https"]
+    patterns_to_match  = ["/*"]
+    frontend_endpoints = ["frontend-default"]
+    forwarding_configuration {
+      forwarding_protocol = "HttpsOnly"
+      backend_pool_name   = "backend-default"
+    }
+  }
+
+  backend_pool_load_balancing {
+    name = "loadbalancing-default"
+  }
+
+  backend_pool_health_probe {
+    name     = "healthprobe-default"
+    protocol = "Https"
+  }
+
+  backend_pool {
+    name = "backend-default"
+
+    dynamic "backend" {
+      for_each = local.frontdoor_hosts
+      content {
+        host_header = backend.value.host
+        address     = backend.value.host
+        http_port   = 80
+        https_port  = 443
+      }
+    }
+
+    load_balancing_name = "loadbalancing-default"
+    health_probe_name   = "healthprobe-default"
+  }
+
+  frontend_endpoint {
+    name                              = "frontend-default"
+    host_name                         = coalesce(var.custom_domain, "${var.name}.azurefd.net")
+    custom_https_provisioning_enabled = false
+  }
 }

--- a/modules/traffic/variables.tf
+++ b/modules/traffic/variables.tf
@@ -29,3 +29,12 @@ variable "custom_domain" {
   type        = string
   default     = ""
 }
+
+variable "tls_certificate" {
+  description = "Source to retrieve an tls/ssl certificate for the service"
+  type = object({
+    source      = string
+    secret_id   = optional(string)
+    keyvault_id = optional(string)
+  })
+}

--- a/modules/traffic/variables.tf
+++ b/modules/traffic/variables.tf
@@ -15,3 +15,17 @@ variable "azure_endpoint_resources" {
     location = string
   }))
 }
+
+variable "static_endpoint_resources" {
+  description = "Endpoint resources to be included in front door"
+  type = map(object({
+    id   = string
+    host = string
+  }))
+}
+
+variable "custom_domain" {
+  description = "Custom domain name to use for exposing the service"
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,8 @@ variable "microservices" {
       name          = string
       description   = string
     })))
+    custom_domain   = optional(string)
+    ssl_certificate_source  = optional(string)
     http = optional(object({
       target    = string
       consumers = list(string)
@@ -141,7 +143,6 @@ variable "microservices" {
     static_site = optional(object({
       index_document = string
       error_document = string
-      domain         = string
     }))
   }))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -120,13 +120,16 @@ variable "microservices" {
         })
     ) })))
     scopes = optional(list(object({
-      id            = string
-      type          = string
-      name          = string
-      description   = string
+      id          = string
+      type        = string
+      name        = string
+      description = string
     })))
-    custom_domain   = optional(string)
-    ssl_certificate_source  = optional(string)
+    custom_domain = optional(string)
+    tls_certificate = optional(object({
+      source    = string
+      secret_id = string
+    }))
     http = optional(object({
       target    = string
       consumers = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -127,8 +127,9 @@ variable "microservices" {
     })))
     custom_domain = optional(string)
     tls_certificate = optional(object({
-      source    = string
-      secret_id = string
+      source      = string
+      secret_id   = string
+      keyvault_id = string
     }))
     http = optional(object({
       target    = string


### PR DESCRIPTION
Adding the ability to specify custom domains for a microservice. This will enable services to be exposed with custom domains so that:

1. Ensure the static site custom domain value is set correctly
2. Ensure that web app based microservices (app_service, function) have their custom domains set correctly
3. Add the correct authentication callback urls with the custom domain so users are authenticated correctly
4. Enable App Service Managed Certificates for web app based microservices

_Note: When Azure Front Door is implemented, will move the static site custom domain routing to there._