### PR TITLE
Features/seanmul/create sql admin flag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -332,7 +332,7 @@ resource "azurerm_key_vault_secret" "sql_admin_password" {
 }
 
 resource "azuread_group" "sql_admin" {
-  count        = local.has_sql_server && (!local.has_sql_admin && var.create_sql_admin) ? 1 : 0
+  count        = local.has_sql_server && local.create_sql_admin ? 1 : 0
   display_name = "${local.admin_login}-sql"
 }
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -254,6 +254,12 @@ variable "sql_azuread_administrator" {
   default     = ""
 }
 
+variable "create_sql_admin" {
+  description = "Create an Azure Active Directory group to use as the SQL admin."
+  type        = bool
+  default     = true
+}
+
 variable "sql_minimum_tls_version" {
   description = "SQL Server minimum TLS version"
   type        = string


### PR DESCRIPTION
Adds a new flag for suppressing the creation of an Azure AD Sql admin group. The permission scope for group creation may not always practically be assumed to be true.