### PR TITLE
Adding Allowed Origins for Static Sites

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -442,6 +442,7 @@ module "microservice" {
   application_permissions         = each.value.application_permissions
   sql                             = each.value.sql
   roles                           = each.value.roles
+  allowed_origins                 = each.value.allowed_origins
   http                            = each.value.http
   scopes                          = each.value.scopes
   cosmos_containers               = each.value.cosmos_containers == null ? [] : each.value.cosmos_containers

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -482,7 +482,7 @@ resource "azurerm_app_service" "microservice" {
     #dotnet_framework_version = "v5.0"
     #websockets_enabled = true # Will need for Blazor hosted appservice
     cors {
-      allowed_origins = var.allowed_origins
+      allowed_origins = local.allowed_origins
     }
   }
 

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -31,8 +31,8 @@ locals {
   http_target                        = local.has_http ? var.http.target : local.has_appservice ? "appservice" : local.has_function ? "function" : null
   consumers                          = local.has_http ? var.http.consumers != null ? var.http.consumers : [] : []
   has_static_site                    = var.static_site != null
-  has_custom_domain                  = var.custom_domain != null && var.custom_domain != ""
   allowed_origins                    = var.allowed_origins != null ? var.allowed_origins : [""]
+  has_custom_domain                  = var.custom_domain != null && var.custom_domain != ""
   tls_certificate_source             = var.tls_certificate != null ? var.tls_certificate.source != null ? lower(var.tls_certificate.source) : "" : ""
   has_application_permissions        = var.application_permissions != null
   application_permissions            = local.has_application_permissions ? var.application_permissions : []

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -363,3 +363,9 @@ variable "static_site" {
   })
   default = null
 }
+
+variable "allowed_origins" {
+  description = "Orgins that are allowed to access the application (CORS)"
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -112,6 +112,7 @@ variable "microservices" {
     require_auth = optional(bool)
     sql          = optional(string)
     roles        = optional(list(string))
+    allowed_origins = optional(list(string))
     application_permissions = optional(list(object({
       resource_app_id = string
       resource_access = list(object({


### PR DESCRIPTION
When a static site calls an Azure Function or App Service, the origin needs to be specified in CORS for that object.

Adding the ability to optionally specify an 'allowed_origins' per microservice so the CORS origins are properly set on the functions/app services created.