### PR TITLE
Specify Custom Application ID URIs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -438,6 +438,7 @@ module "microservice" {
   appservice                      = each.value.appservice
   function                        = each.value.function
   require_auth                    = each.value.require_auth == null ? false : each.value.require_auth
+  application_identifier_uris     = each.value.application_identifier_uris
   application_owners              = local.application_owners
   application_permissions         = each.value.application_permissions
   sql                             = each.value.sql

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -35,6 +35,7 @@ locals {
   tls_certificate_source             = var.tls_certificate != null ? var.tls_certificate.source != null ? lower(var.tls_certificate.source) : "" : ""
   has_application_permissions        = var.application_permissions != null
   application_permissions            = local.has_application_permissions ? var.application_permissions : []
+  application_identifier_uris        = var.application_identifier_uris != null ? var.application_identifier_uris : [lower("api://${local.full_microservice_environment_name}")]
   application_scopes                 = var.scopes != null ? var.scopes : []
 
   graph_resource_app_id         = "00000003-0000-0000-c000-000000000000"
@@ -226,7 +227,7 @@ resource "azuread_application" "microservice" {
   display_name               = local.full_microservice_environment_name
   prevent_duplicate_names    = true
   oauth2_allow_implicit_flow = true
-  identifier_uris            = [lower("api://${local.full_microservice_environment_name}")]
+  identifier_uris            = local.application_identifier_uris
   owners                     = var.application_owners
   group_membership_claims    = "None"
   oauth2_permissions         = []

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -182,11 +182,11 @@ variable "custom_domain" {
 
 variable "tls_certificate" {
   description = "Source to retrieve an tls/ssl certificate for the service"
-  type        = object({
-      source        = string
-      secret_id     = optional(string)
-      keyvault_id   = optional(string)
-    })
+  type = object({
+    source      = string
+    secret_id   = optional(string)
+    keyvault_id = optional(string)
+  })
 }
 
 variable "azuread_instance" {
@@ -376,4 +376,10 @@ variable "static_site" {
     storage_tls_version      = string
   })
   default = null
+}
+
+variable "application_identifier_uris" {
+  description = "A list of URI(s) that uniquely identify an application within it's Azure AD tenant, or within a verified custom domain if the application is multi-tenant"
+  type        = list(string)
+  default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -106,12 +106,13 @@ variable "signed_out_callback_path" {
 variable "microservices" {
   description = "This will describe your microservices to determine which resources are needed"
   type = list(object({
-    name         = string
-    appservice   = optional(string)
-    function     = optional(string)
-    require_auth = optional(bool)
-    sql          = optional(string)
-    roles        = optional(list(string))
+    name                        = string
+    appservice                  = optional(string)
+    function                    = optional(string)
+    require_auth                = optional(bool)
+    sql                         = optional(string)
+    roles                       = optional(list(string))
+    application_identifier_uris = optional(list(string))
     application_permissions = optional(list(object({
       resource_app_id = string
       resource_access = list(object({

--- a/variables.tf
+++ b/variables.tf
@@ -113,7 +113,7 @@ variable "microservices" {
     sql                         = optional(string)
     roles                       = optional(list(string))
     application_identifier_uris = optional(list(string))
-    allowed_origins = optional(list(string))
+    allowed_origins             = optional(list(string))
     application_permissions = optional(list(object({
       resource_app_id = string
       resource_access = list(object({


### PR DESCRIPTION
Adding the ability to optionally specify the application identifier uris for the underlying microservice application.  This is needed for some cases where the authenticated application URI must match the http host being called, amongst others.

Application Identifier URI:
 _A list of user-defined URI(s) that uniquely identify a Web application within it's Azure AD tenant, or within a verified custom domain if the application is multi-tenant._