### PR TITLE
Ensuring App Settings are not Deleted

### DIFF
--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -556,6 +556,13 @@ resource "azurerm_app_service" "microservice" {
       issuer           = "https://sts.windows.net/${var.azurerm_client_config.tenant_id}"
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      # Leave app_settings as-is once created since they can be updated by the service
+      app_settings,
+    ]
+  }
 }
 
 locals {
@@ -609,6 +616,13 @@ resource "azurerm_function_app" "microservice" {
       default_provider = "AzureActiveDirectory"
       issuer           = "https://sts.windows.net/${var.azurerm_client_config.tenant_id}"
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # Leave app_settings as-is once created since they can be updated by the service
+      app_settings,
+    ]
   }
 
 }


### PR DESCRIPTION
Updated the app_settings to be ignored after creation.  This will allow additional app settings defined by the service (such as feature flags) to be persisted when an infrastructure update is made.