### PR TITLE
Fixing FrontDoor Custom Domains

### DIFF
--- a/modules/traffic/main.tf
+++ b/modules/traffic/main.tf
@@ -9,7 +9,7 @@ locals {
 
   has_custom_domain      = var.custom_domain != null && var.custom_domain != ""
   has_tls_certificate    = var.tls_certificate != null ? var.tls_certificate.source != null : false
-  tls_certificate_source = local.has_tls_certificate ? lower(var.tls_certificate.source) == "frontdoor" ? "FrontDoor" : lower(var.tls_certificate.source) == "keyvault" ? "AzureKeyVault" : "" : ""
+  tls_certificate_source = local.has_tls_certificate ? lower(var.tls_certificate.source) == "keyvault" ? "AzureKeyVault" : "" : ""
 
   has_kevault_secret      = local.tls_certificate_source == "AzureKeyVault"
   keyvault_secret_parts   = local.has_kevault_secret ? split("/", var.tls_certificate.secret_id) : []
@@ -155,7 +155,7 @@ resource "azurerm_frontdoor" "microservice" {
     content {
       name                              = "frontend-custom"
       host_name                         = var.custom_domain
-      custom_https_provisioning_enabled = local.has_tls_certificate
+      custom_https_provisioning_enabled = true
 
       # Note: FrontDoor managed certificates are the default certificate source.  Only need to specify KeyVault if
       #       you want to manage yourself.

--- a/modules/traffic/main.tf
+++ b/modules/traffic/main.tf
@@ -60,7 +60,7 @@ resource "azurerm_frontdoor" "microservice" {
 
   routing_rule {
     name               = "routing-default"
-    accepted_protocols = ["Https"]
+    accepted_protocols = ["Https", "Http"]
     patterns_to_match  = ["/*"]
     frontend_endpoints = ["frontend-default"]
     forwarding_configuration {
@@ -73,7 +73,7 @@ resource "azurerm_frontdoor" "microservice" {
     for_each = local.has_custom_domain ? [true] : []
     content {
       name               = "routing-custom"
-      accepted_protocols = ["Https"]
+      accepted_protocols = ["Https", "Http"]
       patterns_to_match  = ["/*"]
       frontend_endpoints = ["frontend-custom"]
       forwarding_configuration {
@@ -157,12 +157,8 @@ resource "azurerm_frontdoor" "microservice" {
       host_name                         = var.custom_domain
       custom_https_provisioning_enabled = local.has_tls_certificate
 
-      dynamic "custom_https_configuration" {
-        for_each = local.tls_certificate_source == "FrontDoor" ? [true] : []
-        content {
-          certificate_source = local.tls_certificate_source
-        }
-      }
+      # Note: FrontDoor managed certificates are the default certificate source.  Only need to specify KeyVault if
+      #       you want to manage yourself.
 
       dynamic "custom_https_configuration" {
         for_each = local.tls_certificate_source == "AzureKeyVault" ? [true] : []

--- a/modules/traffic/main.tf
+++ b/modules/traffic/main.tf
@@ -69,13 +69,42 @@ resource "azurerm_frontdoor" "microservice" {
     }
   }
 
+  dynamic "routing_rule" {
+    for_each = local.has_custom_domain ? [true] : []
+    content {
+      name               = "routing-custom"
+      accepted_protocols = ["Https"]
+      patterns_to_match  = ["/*"]
+      frontend_endpoints = ["frontend-custom"]
+      forwarding_configuration {
+        forwarding_protocol = "HttpsOnly"
+        backend_pool_name   = "backend-custom"
+      }
+    }
+  }
+
   backend_pool_load_balancing {
     name = "loadbalancing-default"
+  }
+
+  dynamic "backend_pool_load_balancing" {
+    for_each = local.has_custom_domain ? [true] : []
+    content {
+      name = "loadbalancing-custom"
+    }
   }
 
   backend_pool_health_probe {
     name     = "healthprobe-default"
     protocol = "Https"
+  }
+
+  dynamic "backend_pool_health_probe" {
+    for_each = local.has_custom_domain ? [true] : []
+    content {
+      name     = "healthprobe-custom"
+      protocol = "Https"
+    }
   }
 
   backend_pool {
@@ -95,34 +124,56 @@ resource "azurerm_frontdoor" "microservice" {
     health_probe_name   = "healthprobe-default"
   }
 
+  dynamic "backend_pool" {
+    for_each = local.has_custom_domain ? [true] : []
+    content {
+      name = "backend-custom"
+
+      dynamic "backend" {
+        for_each = local.frontdoor_hosts
+        content {
+          host_header = backend.value
+          address     = backend.value
+          http_port   = 80
+          https_port  = 443
+        }
+      }
+
+      load_balancing_name = "loadbalancing-custom"
+      health_probe_name   = "healthprobe-custom"
+    }
+  }
+
   frontend_endpoint {
     name                              = "frontend-default"
-    host_name                         = local.has_custom_domain ? var.custom_domain : "${var.name}.azurefd.net"
+    host_name                         = "${var.name}.azurefd.net"
     custom_https_provisioning_enabled = false
   }
-}
 
-resource "azurerm_frontdoor_custom_https_configuration" "microservice_frontdoor" {
-  count = local.has_frontdoor_resources && local.tls_certificate_source == "FrontDoor" ? 1 : 0
+  dynamic "frontend_endpoint" {
+    for_each = local.has_custom_domain ? [true] : []
+    content {
+      name                              = "frontend-custom"
+      host_name                         = var.custom_domain
+      custom_https_provisioning_enabled = local.has_tls_certificate
 
-  frontend_endpoint_id              = azurerm_frontdoor.microservice[0].frontend_endpoint[0].id
-  custom_https_provisioning_enabled = true
+      dynamic "custom_https_configuration" {
+        for_each = local.tls_certificate_source == "FrontDoor" ? [true] : []
+        content {
+          certificate_source = local.tls_certificate_source
+        }
+      }
 
-  custom_https_configuration {
-    certificate_source = local.tls_certificate_source
+      dynamic "custom_https_configuration" {
+        for_each = local.tls_certificate_source == "AzureKeyVault" ? [true] : []
+        content {
+          certificate_source                         = local.tls_certificate_source
+          azure_key_vault_certificate_secret_name    = local.keyvault_secret_name
+          azure_key_vault_certificate_secret_version = local.keyvault_secret_version
+          azure_key_vault_certificate_vault_id       = local.keyvault_id
+        }
+      }
+    }
   }
 }
 
-resource "azurerm_frontdoor_custom_https_configuration" "microservice_keyvault" {
-  count = local.has_frontdoor_resources && local.tls_certificate_source == "AzureKeyVault" ? 1 : 0
-
-  frontend_endpoint_id              = azurerm_frontdoor.microservice[0].frontend_endpoint[0].id
-  custom_https_provisioning_enabled = true
-
-  custom_https_configuration {
-    certificate_source                         = local.tls_certificate_source
-    azure_key_vault_certificate_secret_name    = local.keyvault_secret_name
-    azure_key_vault_certificate_secret_version = local.keyvault_secret_version
-    azure_key_vault_certificate_vault_id       = local.keyvault_id
-  }
-}


### PR DESCRIPTION
When using a fully functional custom domain, the existing functionality was breaking since the default frontend / backend / route needs to exist for the CNAME records to be properly mapped to this.

The traffic module was updated so that:
1. The default frontend (<name>.azurefd.net) is always created
2. If the microservice has a custom domain, then it also creates the frontend / backend / route for that maps to the custom domain
3. Custom Domains use https by default and any non https traffic is automatically converted to https