### PR TITLE
Only Query Current User When EnvironmentDifferentiator is not set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ locals {
 data "azurerm_client_config" "current" {}
 
 data "azuread_user" "current_user" {
-  count     = local.is_dev ? 1 : 0
+  count     = local.is_dev && var.environment_differentiator == "" ? 1 : 0
   object_id = data.azurerm_client_config.current.object_id
 }
 


### PR DESCRIPTION
Updating the azuread_user.current_user data resource to only run when the environment differentiator is not set.  The current_user value is only used when deriving the environment_differentiator on user specific dev environments.  When building out a shared dev environment via a service principal (not a user) then the process fails, this is intended to fix that only if the environment differentiator is set (ex: environment="dev", environent_differentiator="shared")